### PR TITLE
chore: add docs/plans to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ db.sqlite3
 
 # Ruff
 .ruff_cache/
+
+# Claude Code plans
+docs/plans/


### PR DESCRIPTION
## Summary
- Add `docs/plans/` to `.gitignore` to exclude Claude Code generated plan files from version control

## Changes
- Updated `.gitignore` to include `docs/plans/`