### PR TITLE
feat: improve output clarity with processing method and separate tile/patch info

### DIFF
--- a/src/vt_calculator/analysts/analyst.py
+++ b/src/vt_calculator/analysts/analyst.py
@@ -74,8 +74,13 @@ class LLaVAAnalyst(VLMAnalyst):
             num_tokens -= 1  # CLS token is excluded in the default strategy
 
         return {
+            "processing_method": "fixed_resolution",
             "number_of_image_patches": num_tokens,
             "patch_size": self.patch_size,
+            "patch_grid": (
+                self.resized_height // self.patch_size,
+                self.resized_width // self.patch_size,
+            ),
             "has_global_patch": False,
             "image_size": image_size,
             "resized_size": (self.resized_height, self.resized_width),
@@ -149,12 +154,18 @@ class LLaVANextAnalyst(VLMAnalyst):
         if self.vision_feature_select_strategy == "default":
             num_image_tokens -= 1  # CLS token is excluded in the default strategy
 
+        patches_per_tile = patches_height * patches_width
+        total_patches = num_patches * patches_per_tile
+
         return {
-            "number_of_image_patches": num_patches,
-            "patch_size": self.patch_size,
+            "processing_method": "tile_based",
             "tile_size": self.tile_size[0],
-            "grid_size": (scale_height, scale_width),
+            "tile_grid": (scale_height, scale_width),
+            "number_of_tiles": num_patches,
             "has_global_patch": True,
+            "patch_size": self.patch_size,
+            "patches_per_tile": patches_per_tile,
+            "total_patches": total_patches,
             "image_size": image_size,
             "resized_size": (resized_height, resized_width),
             "image_token": (self.image_token, num_image_tokens),
@@ -261,12 +272,18 @@ class LlavaOnevisionAnalyst(VLMAnalyst):
         if self.vision_feature_select_strategy == "default":
             num_image_tokens -= 1
 
+        patches_per_tile = patches_height * patches_width
+        total_patches = num_patches * patches_per_tile
+
         return {
-            "number_of_image_patches": num_patches,
-            "patch_size": self.patch_size,
+            "processing_method": "tile_based",
             "tile_size": self.tile_size[0],
-            "grid_size": (scale_height, scale_width),
+            "tile_grid": (scale_height, scale_width),
+            "number_of_tiles": num_patches,
             "has_global_patch": True,
+            "patch_size": self.patch_size,
+            "patches_per_tile": patches_per_tile,
+            "total_patches": total_patches,
             "image_size": image_size,
             "resized_size": (resized_height, resized_width),
             "image_token": (self.image_token, num_image_tokens),
@@ -309,9 +326,10 @@ class Qwen2VLAnalyst(VLMAnalyst):
         num_tokens = num_patches // (self.merge_size**2)
 
         return {
-            "number_of_image_patches": num_patches,
-            "grid_size": (grid_h, grid_w),
+            "processing_method": "native_resolution",
             "patch_size": self.patch_size,
+            "patch_grid": (grid_h, grid_w),
+            "total_patches": num_patches,
             "has_global_patch": False,
             "image_size": image_size,
             "resized_size": (resized_h, resized_w),
@@ -478,13 +496,18 @@ class InternVLAnalyst(VLMAnalyst):
             num_patches += grid_h * grid_w
 
         num_tokens = num_patches * self.image_seq_length
+        patches_per_tile = self.image_seq_length
+        total_patches = num_patches * patches_per_tile
 
         return {
-            "number_of_image_patches": num_patches,
-            "grid_size": (grid_h, grid_w),
+            "processing_method": "tile_based",
             "tile_size": self.tile_size,
-            "patch_size": self.patch_size,
+            "tile_grid": (grid_h, grid_w),
+            "number_of_tiles": num_patches,
             "has_global_patch": num_patches > 1,
+            "patch_size": self.patch_size,
+            "patches_per_tile": patches_per_tile,
+            "total_patches": total_patches,
             "image_size": image_size,
             "resized_size": (self.tile_size * grid_h, self.tile_size * grid_w),
             "image_token": (self.image_token, num_tokens),
@@ -619,16 +642,20 @@ class DeepSeekOCRAnalyst(VLMAnalyst):
             f"* {num_row} + <image_seperator> = {total_tokens}"
         )
 
+        patch_grid = self.image_size // self.patch_size
+
         return {
+            "processing_method": "native_resolution",
             "image_token": (self.image_token, total_tokens),
             "image_token_format": token_format,
             "image_size": (height, width),
             "resized_size": (self.image_size, self.image_size),
-            "number_of_image_patches": num_patches,
+            "patch_size": self.patch_size,
+            "patch_grid": (patch_grid, patch_grid),
+            "total_patches": num_patches,
             "has_global_patch": False,
             "mode": self.mode,
             "base_size": self.base_size,
-            "patch_size": self.patch_size,
             "num_row": num_row,
         }
 
@@ -681,18 +708,26 @@ class DeepSeekOCRAnalyst(VLMAnalyst):
                 f"* {num_row_base} + <image_seperator> = {total_tokens}"
             )
 
+        has_local_crops = width_tiles > 1 or height_tiles > 1
+        global_patches_per_tile = (self.base_size // self.patch_size) ** 2
+        local_patches_per_tile = (self.image_size // self.patch_size) ** 2 if has_local_crops else 0
+        number_of_tiles = 1 + (width_tiles * height_tiles if has_local_crops else 0)
+
         return {
+            "processing_method": "tile_based",
             "image_token": (self.image_token, total_tokens),
             "image_token_format": token_format,
             "image_size": (height, width),
             "resized_size": (self.base_size, self.base_size),
-            "number_of_image_patches": num_patches,
-            "has_global_patch": width_tiles > 1 or height_tiles > 1,
+            "tile_size": self.image_size,
+            "tile_grid": (height_tiles, width_tiles),
+            "number_of_tiles": number_of_tiles,
+            "has_global_patch": has_local_crops,
+            "patch_size": self.patch_size,
+            "patches_per_tile": local_patches_per_tile if has_local_crops else global_patches_per_tile,
+            "total_patches": num_patches,
             "mode": self.mode,
             "base_size": self.base_size,
-            "patch_size": self.patch_size,
-            "crop_grid": crop_grid,
-            "grid_size": (height_tiles, width_tiles),
             "num_global_tokens": global_tokens,
             "num_local_tokens": local_tokens,
         }

--- a/src/vt_calculator/reporter.py
+++ b/src/vt_calculator/reporter.py
@@ -239,6 +239,17 @@ class Reporter:
         model_table.add_column("Key", style="cyan", ratio=1)
         model_table.add_column("Value", style="bold white", ratio=2)
         model_table.add_row("Model Name", model_name)
+
+        # Add Processing Method
+        processing_method = result.get("processing_method", "")
+        if processing_method:
+            method_display = {
+                "native_resolution": "Native Resolution",
+                "tile_based": "Tile-based",
+                "fixed_resolution": "Fixed Resolution",
+            }.get(processing_method, processing_method)
+            model_table.add_row("Processing Method", method_display)
+
         grid.add_row(
             Panel(
                 model_table,
@@ -282,6 +293,31 @@ class Reporter:
             )
         )
 
+        # TILE INFO (for tile-based models)
+        if not is_video and processing_method == "tile_based":
+            tile_table = Table(box=box.SIMPLE, show_header=False, expand=True)
+            tile_table.add_column("Key", style="cyan", ratio=1)
+            tile_table.add_column("Value", style="bold white", ratio=2)
+
+            tile_table.add_row("Tile Size", str(result.get("tile_size", "N/A")))
+            if "tile_grid" in result:
+                tile_table.add_row(
+                    "Tile Grid (H×W)",
+                    f"{result['tile_grid'][0]}×{result['tile_grid'][1]}",
+                )
+            num_tiles = result.get("number_of_tiles", "N/A")
+            global_note = " (incl. global)" if result.get("has_global_patch") else ""
+            tile_table.add_row("Number of Tiles", f"{num_tiles}{global_note}")
+
+            grid.add_row(
+                Panel(
+                    tile_table,
+                    title="[bold]TILE INFO[/bold]",
+                    border_style="yellow",
+                    box=box.ROUNDED,
+                )
+            )
+
         # PATCH INFO
         patch_table = Table(box=box.SIMPLE, show_header=False, expand=True)
         patch_table.add_column("Key", style="cyan", ratio=1)
@@ -293,20 +329,36 @@ class Reporter:
                     "Grid Size (per frame)",
                     f"{result['grid_size'][0]} x {result['grid_size'][1]}",
                 )
-        else:
+        elif processing_method == "tile_based":
+            # Tile-based: show patch info within tiles
             patch_table.add_row(
                 "Patch Size (ViT)", str(result.get("patch_size", "N/A"))
             )
-            if "tile_size" in result:
-                patch_table.add_row("Tile Size", str(result["tile_size"]))
-            if "grid_size" in result:
+            patches_per_tile = result.get("patches_per_tile", "N/A")
+            if patches_per_tile != "N/A":
+                tile_size = result.get("tile_size", 0)
+                patch_size = result.get("patch_size", 1)
+                if tile_size and patch_size:
+                    patches_dim = tile_size // patch_size
+                    patch_table.add_row(
+                        "Patches per Tile",
+                        f"{patches_per_tile} ({patches_dim}×{patches_dim})",
+                    )
+            patch_table.add_row(
+                "Total Patches", str(result.get("total_patches", "N/A"))
+            )
+        else:
+            # Native resolution / Fixed resolution
+            patch_table.add_row(
+                "Patch Size (ViT)", str(result.get("patch_size", "N/A"))
+            )
+            if "patch_grid" in result:
                 patch_table.add_row(
-                    "Grid Size (H×W)",
-                    f"{result['grid_size'][0]}×{result['grid_size'][1]}",
+                    "Patch Grid (H×W)",
+                    f"{result['patch_grid'][0]}×{result['patch_grid'][1]}",
                 )
             patch_table.add_row(
-                "Number of Patches",
-                f"{result['number_of_image_patches']} {'(global patch)' if result.get('has_global_patch') else ''}",
+                "Total Patches", str(result.get("total_patches", result.get("number_of_image_patches", "N/A")))
             )
 
         grid.add_row(

--- a/tests/test_deepseek_ocr.py
+++ b/tests/test_deepseek_ocr.py
@@ -127,11 +127,11 @@ class TestDeepSeekOCRGundamMode:
         # Only global tokens (no local crops)
         assert result_exact["image_token"][1] == 273
         assert result_small["image_token"][1] == 273
-        assert result_exact.get("crop_grid") == (1, 1)
+        assert result_exact.get("tile_grid") == (1, 1)
         assert result_exact.get("num_local_tokens", 0) == 0
 
     def test_gundam_wide_image_4x2_crops(self):
-        """Wide image (1920x1080, aspect~1.78) -> (4,2) tiles.
+        """Wide image (1920x1080, aspect~1.78) -> (2,4) tiles (H×W).
 
         Aspect ratio 1.78 is equidistant from (2,1)=2.0 and (4,2)=2.0.
         Tie-breaker favors more tiles when area justifies it.
@@ -148,11 +148,11 @@ class TestDeepSeekOCRGundamMode:
         expected_local = (10 * 4 + 1) * (10 * 2)  # 820
         expected_total = 273 + expected_local  # 1093
 
-        assert result["crop_grid"] == (4, 2)  # (width_tiles, height_tiles)
+        assert result["tile_grid"] == (2, 4)  # (height_tiles, width_tiles) = (H×W)
         assert result["image_token"][1] == expected_total
 
     def test_gundam_tall_image_2x4_crops(self):
-        """Tall image (1080x1920, aspect~0.56) -> (2,4) tiles.
+        """Tall image (1080x1920, aspect~0.56) -> (4,2) tiles (H×W).
 
         Aspect ratio 0.56 is equidistant from (1,2)=0.5 and (2,4)=0.5.
         Tie-breaker favors more tiles when area justifies it.
@@ -169,7 +169,7 @@ class TestDeepSeekOCRGundamMode:
         expected_local = (10 * 2 + 1) * (10 * 4)  # 840
         expected_total = 273 + expected_local  # 1113
 
-        assert result["crop_grid"] == (2, 4)  # (width_tiles, height_tiles)
+        assert result["tile_grid"] == (4, 2)  # (height_tiles, width_tiles) = (H×W)
         assert result["image_token"][1] == expected_total
 
     def test_gundam_square_large_image_2x2_crops(self):
@@ -187,11 +187,11 @@ class TestDeepSeekOCRGundamMode:
         expected_local = (10 * 2 + 1) * (10 * 2)  # 420
         expected_total = 273 + expected_local  # 693
 
-        assert result["crop_grid"] == (2, 2)
+        assert result["tile_grid"] == (2, 2)
         assert result["image_token"][1] == expected_total
 
     def test_gundam_very_wide_image_4x1_crops(self):
-        """Very wide image (2560x720, aspect~3.56) -> (4,1) tiles.
+        """Very wide image (2560x720, aspect~3.56) -> (1,4) tiles (H×W).
 
         Aspect ratio 3.56 is closer to (4,1)=4.0 than (3,1)=3.0.
         diff(3.56, 4.0) = 0.44 < diff(3.56, 3.0) = 0.56
@@ -208,7 +208,7 @@ class TestDeepSeekOCRGundamMode:
         expected_local = (10 * 4 + 1) * (10 * 1)  # 410
         expected_total = 273 + expected_local  # 683
 
-        assert result["crop_grid"] == (4, 1)
+        assert result["tile_grid"] == (1, 4)  # (height_tiles, width_tiles) = (H×W)
         assert result["image_token"][1] == expected_total
 
 
@@ -285,12 +285,17 @@ class TestDeepSeekOCROutputFormat:
         result = analyst.calculate_image((1024, 1024))
 
         required_keys = [
+            "processing_method",
             "image_token",
             "image_token_format",
             "image_size",
+            "resized_size",
+            "patch_size",
+            "patch_grid",
+            "total_patches",
+            "has_global_patch",
             "mode",
             "base_size",
-            "patch_size",
         ]
         for key in required_keys:
             assert key in result, f"Missing required key: {key}"
@@ -315,10 +320,12 @@ class TestDeepSeekOCROutputFormat:
         analyst = DeepSeekOCRAnalyst(mode="gundam")
         result = analyst.calculate_image((1920, 1080))
 
-        assert "crop_grid" in result
+        assert result["processing_method"] == "tile_based"
+        assert "tile_grid" in result
+        assert "number_of_tiles" in result
         assert "num_global_tokens" in result
         assert "num_local_tokens" in result
-        assert isinstance(result["crop_grid"], tuple)
+        assert isinstance(result["tile_grid"], tuple)
 
 
 class TestDeepSeekOCRVideo:
@@ -407,7 +414,7 @@ class TestDeepSeekOCREdgeCases:
 
         # Small images get no crops, only global view
         assert result["image_token"][1] == 273
-        assert result["crop_grid"] == (1, 1)
+        assert result["tile_grid"] == (1, 1)
 
     def test_very_large_image_respects_max_crops(self):
         """Very large images should respect max_crops=9 limit."""
@@ -417,8 +424,8 @@ class TestDeepSeekOCREdgeCases:
         result = analyst.calculate_image((5000, 5000))
 
         # Should be limited to 3x3 = 9 crops max
-        width_tiles, height_tiles = result["crop_grid"]
-        assert width_tiles * height_tiles <= 9
+        height_tiles, width_tiles = result["tile_grid"]  # (H×W)
+        assert height_tiles * width_tiles <= 9
 
     def test_extreme_aspect_ratio_wide(self):
         """Extremely wide images should work."""
@@ -428,7 +435,7 @@ class TestDeepSeekOCREdgeCases:
         result = analyst.calculate_image((480, 6000))  # very wide
 
         assert result["image_token"][1] > 273  # has crops
-        width_tiles, height_tiles = result["crop_grid"]
+        height_tiles, width_tiles = result["tile_grid"]  # (H×W)
         assert width_tiles > height_tiles
 
     def test_extreme_aspect_ratio_tall(self):
@@ -439,7 +446,7 @@ class TestDeepSeekOCREdgeCases:
         result = analyst.calculate_image((6000, 480))  # very tall
 
         assert result["image_token"][1] > 273  # has crops
-        width_tiles, height_tiles = result["crop_grid"]
+        height_tiles, width_tiles = result["tile_grid"]  # (H×W)
         assert height_tiles > width_tiles
 
 


### PR DESCRIPTION
## Summary
- Add Processing Method display to MODEL INFO section (Native Resolution, Tile-based, Fixed Resolution)
- Separate TILE INFO and PATCH INFO sections for tile-based models
- Clearer distinction between tile-based and native resolution models

## Changes

### Before
Tile-based models showed confusing "Number of Patches" which actually meant number of tiles.

### After
**Native Resolution models (Qwen series, DeepSeek-OCR native):**
```
╭─────────────── MODEL INFO ───────────────╮
│   Model Name           qwen2.5-vl        │
│   Processing Method    Native Resolution │
╰──────────────────────────────────────────╯
╭─────────────── PATCH INFO ───────────────╮
│   Patch Size (ViT)     14                │
│   Patch Grid (H×W)     138×78            │
│   Total Patches        10764             │
╰──────────────────────────────────────────╯
```

**Tile-based models (LLaVA-NeXT, InternVL, DeepSeek-OCR gundam):**
```
╭─────────────── MODEL INFO ───────────────╮
│   Model Name           llava-next        │
│   Processing Method    Tile-based        │
╰──────────────────────────────────────────╯
╭─────────────── TILE INFO ────────────────╮
│   Tile Size            336               │
│   Tile Grid (H×W)      2×2               │
│   Number of Tiles      5 (incl. global)  │
╰──────────────────────────────────────────╯
╭─────────────── PATCH INFO ───────────────╮
│   Patch Size (ViT)     14                │
│   Patches per Tile     576 (24×24)       │
│   Total Patches        2880              │
╰──────────────────────────────────────────╯
```

## Test Plan
- [x] All DeepSeek-OCR tests pass
- [x] Verified output for qwen2.5-vl, llava-next, internvl3, deepseek-ocr-tiny, deepseek-ocr-gundam